### PR TITLE
Remove `credits.markdown` from compiled sources

### DIFF
--- a/EventBlank/EventBlank2-iOS.xcodeproj/project.pbxproj
+++ b/EventBlank/EventBlank2-iOS.xcodeproj/project.pbxproj
@@ -38,7 +38,6 @@
 		9C24D4EF1C83A55F00B1F0A2 /* MDViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C24D4E41C8399F400B1F0A2 /* MDViewController.swift */; };
 		9C24D4F21C83A72E00B1F0A2 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C24D4F11C83A72E00B1F0A2 /* WebViewController.swift */; };
 		9C24D4F31C83A92100B1F0A2 /* CreditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C24D4E51C8399F400B1F0A2 /* CreditViewController.swift */; };
-		9C24D4F41C83AA4B00B1F0A2 /* credits.markdown in Sources */ = {isa = PBXBuildFile; fileRef = 9C24D4E71C8399F400B1F0A2 /* credits.markdown */; };
 		9C24D4F51C83AA8100B1F0A2 /* credits.markdown in Resources */ = {isa = PBXBuildFile; fileRef = 9C24D4E71C8399F400B1F0A2 /* credits.markdown */; };
 		9C24D4F71C83AB6400B1F0A2 /* Pods-acknowledgements.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9C24D4F61C83AB6400B1F0A2 /* Pods-acknowledgements.plist */; };
 		9C4216261C77C14A003321FC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4216251C77C14A003321FC /* AppDelegate.swift */; };
@@ -643,7 +642,6 @@
 				9C64EDC21C7B31F800985D51 /* SpeakersViewController+Search.swift in Sources */,
 				9C1B20E31C77C7B800DE7A1A /* Shared.swift in Sources */,
 				9C558E6A1C7B10D6009830D5 /* SpeakersViewController.swift in Sources */,
-				9C24D4F41C83AA4B00B1F0A2 /* credits.markdown in Sources */,
 				9C1B21071C785CC200DE7A1A /* Location.swift in Sources */,
 				9C1F11741C7C6BF0009AFC2D /* Favorite.swift in Sources */,
 				9CCCAB1B1C954AFA00B4C561 /* TwitterProvider.swift in Sources */,


### PR DESCRIPTION
`credits.markdown` file was accidentally in compiled sources of the project, this fixes a warning.
